### PR TITLE
infra: adicionado base do docker para frontend e backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  # --- SERVIÇO DO BACKEND ---
+  fivelib-api:
+    build: 
+      context: ./backend      
+    container_name: fivelib-api
+    ports:
+      - "8001:8001"
+    volumes:
+      - ./backend:/app
+    command: uvicorn main:app --host 0.0.0.0 --port 8001 --reload
+    restart: unless-stopped
+
+  # --- SERVIÇO DO FRONTEND ---
+  fivelib-frontend:
+    build: 
+      context: ./frontend
+    container_name: fivelib-frontend
+    ports:
+      - "3000:3000"
+      - "5173:5173"         # Porta padrão de React/Next/Vite.
+    volumes:
+      - ./frontend:/app       # Sincroniza o código do front para hot-reload.
+      - /app/node_modules     # Protege os node_modules internos do container.
+    environment:
+      - VITE_API_URL=http://localhost:8001 # Variável para o front achar a API.
+    # depends_on:
+    #  - fivelib-api           # Garante que o front só sobe DEPOIS da API.
+    restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Copia os arquivos de dependência primeiro (boa prática de cache do Docker).
+COPY package.json package-lock.json* ./
+
+# Instala as dependências.
+RUN npm install
+
+# Copia o resto do projeto.
+COPY . .
+
+# Comando padrão para rodar a maioria dos frameworks JS em desenvolvimento.
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
- Adicionando infraestrutura do DOCKER adequando-se a necessidade do planejamento do projeto:
   - O uso dos framework em frontend, o dockerfile foi configurado para usar o package.json esperando recebe isso.
   - Também foi desacoplado de forma iniciativa, assim caso utilize o comando docker compose up --build, ele não espera o backend.