### PR TITLE
Revert "chore(deps): bump gitpython from 3.0.6 to 3.1.50 in /backend"

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ fastapi==0.136.1
 fsspec==2026.4.0
 gitdb==4.0.12
 gitdb2==4.0.2
-GitPython==3.1.50
+GitPython==3.0.6
 greenlet==3.5.0
 h11==0.16.0
 h2==4.3.0


### PR DESCRIPTION
Reverts fivelibx/fivelib#121